### PR TITLE
fix: fixed SQLBoiler version to v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.5](https://github.com/locona/action-sqlboiler/compare/v1.0.4...v1.0.5) (2021-12-20)
+
+
+### Bug Fixes
+
+* **docker:** update Dockerfile for sqlboiler-mysql ([#40](https://github.com/locona/action-sqlboiler/issues/40)) ([3f09ac1](https://github.com/locona/action-sqlboiler/commit/3f09ac1bf31052c15aa68fc720a5af4f1a2d8bf0))
+
 ### [1.0.4](https://github.com/locona/action-sqlboiler/compare/v1.0.3...v1.0.4) (2020-04-21)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.16-alpine
 
 ENV GO111MODULE=on
+ARG SQLBOILER_VERSION="v4.5.0"
 
 RUN apk --no-cache add git bash && \
-    go get -u -t github.com/volatiletech/sqlboiler/v4 && \
-    go get github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-mysql
+    go install github.com/volatiletech/sqlboiler/v4@${SQLBOILER_VERSION} && \
+    go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-mysql@${SQLBOILER_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
# Why

Reckonerで、Github Actionsのsqlboilerコマンドが動作しなくなっていたため修正

# How

* 元の最新masterブランチを元に、featureブランチを切り出し
* Sqlboilerのバージョンを、Reckoner側に合わせて v4.5.0 へ変更


# 確認方法

以下でテストをして動作することを確認しています。

テストブランチ
https://github.com/3-shake/reckoner-cdp/pull/6582

修正内容
https://github.com/3-shake/reckoner-cdp/pull/6582/commits/f08182f2173d219b0d54608628d1e652cb0254ff

github actionsの実行結果
https://github.com/3-shake/reckoner-cdp/runs/6382405365?check_suite_focus=true